### PR TITLE
Make it work in native

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <!-- Quarkus -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.13.3.Final</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.version>2.14.0.CR1</quarkus.platform.version>
         <!-- Libraries -->
         <assertj.version>3.23.1</assertj.version>
         <github-slugify.version>3.0.2</github-slugify.version>
@@ -63,6 +63,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+            <version>22.2.0</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/java/dev/ebullient/pockets/graalvm/SlugifySubstitutions.java
+++ b/src/main/java/dev/ebullient/pockets/graalvm/SlugifySubstitutions.java
@@ -1,0 +1,15 @@
+package dev.ebullient.pockets.graalvm;
+
+import com.github.slugify.Slugify;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(Slugify.class)
+public final class SlugifySubstitutions {
+
+    @Substitute
+    private String transliterate(String input) {
+        throw new IllegalArgumentException("Transliteration capabilities have been disabled, as dependency is missing");
+    }
+
+}


### PR DESCRIPTION
Quick hack, definitely needs some polishing; mainly you shouldn't need the `reflect-config.json` file - I should fold those rules into the Quarkus H2 extensions.

Compile with:

> mvn package -DskipTests -Dnative

run:

> ./target/pockets-cli-199-SNAPSHOT-runner

Requires a recent Quarkus `main` build locally (depends on version `999-SNAPSHOT`).

